### PR TITLE
glossary.rst: fix TODO comment markup

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -54,9 +54,9 @@ Glossary of Terms
        commands/manifests and to send reports in :term:`daemon mode`.
 
    .. TODO(larsbutler): Add a more detailed `manifest` page and link
-      it here. It would be nice to basically link to a detailed page
-      containing all of this:
-      https://github.com/zerovm/zerovm/blob/master/doc/manifest.txt
+   .. it here. It would be nice to basically link to a detailed page
+   .. containing all of this:
+   .. https://github.com/zerovm/zerovm/blob/master/doc/manifest.txt
 
    Native Client
    NaCl
@@ -83,7 +83,7 @@ Glossary of Terms
        <http://en.wikipedia.org/wiki/Unix_time>`_.)
 
    .. TODO(larsbutler): Linked more detailed docs page here, with a
-      full description of the NVRAM file and all of its fields.
+   .. full description of the NVRAM file and all of its fields.
 
    Trusted
 


### PR DESCRIPTION
Commit b853ad906a2e0527e0313fb70d42137ae2d7aa11 added the sphinx
`glossary` directive, but it broke the TODO comments that were written
into the page. Indenting these multi-line comment blocks caused the
comment text after the first line of the block to bleed into the page.
