### PR TITLE
zebra/tutorial.rst: use the new `zpm execute` cmd

### DIFF
--- a/zebra/tutorial.rst
+++ b/zebra/tutorial.rst
@@ -249,6 +249,13 @@ do so, we need to pick an existing Swift container as our deployment target.
     $ zpm deploy mycontainer hello.zapp
     $ zpm execute mycontainer hello.zapp
 
+.. tip::
+
+    You can also deploy and execute a zapp using a single ``deploy`` command.
+    For example:
+
+    ``$ zpm deploy mycontainer hello.zapp --execute``
+
 
 .. _zebra-system-info-sample:
 


### PR DESCRIPTION
Previously, it was required to use the `zpm deploy ...  --execute`
command to remotely execute zapps on ZeroCloud. We now have a separate
command for execution in zpm. This change updates the tutorial to use
separate `zpm deploy` and `zpm execute` commands.
