### PR TITLE
Make contribution guidelines more friendly

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -42,7 +42,8 @@ process looks like this:
 
 Feel free to remind us on :ref:`IRC or the mailinglist <contact-us>`
 if it takes more than a couple of days for us to respond to a pull
-request.
+request. The IRC channel is also a great place to get some real-time
+feedback on a pull request.
 
 
 Rebasing


### PR DESCRIPTION
As discussed at the OpenStack Summit in Atlanta, we want the contribution guidelines to be as friendly and inviting as possible.

This is an attempt at making them more inviting by stressing that we want to build a great community and work with people to better support their use cases.
