### PR TITLE
Fixes to `contact` page

### DIFF
--- a/contact.rst
+++ b/contact.rst
@@ -15,13 +15,13 @@ We host our mailing lists at Google Groups. We have two mailing lists:
 
 * A list for users: zerovm@googlegroups.com. This is a list for
   general discussion about ZeroVM: what is it, how to install it, etc,
-  Please `signup on Google Groups`__.
+  Please `sign up on Google Groups`__.
 
   .. __: https://groups.google.com/forum/#!forum/zerovm
 
 * A list for development: zerovm-devel@googlegroups.com. This list is used
   for discussion about the ongoing development of ZeroVM. Please
-  `signup on Google Groups`__.
+  `sign up on Google Groups`__.
 
   .. __: https://groups.google.com/forum/#!forum/zerovm-devel
 


### PR DESCRIPTION
This change makes some minor fixes to the contact page:
- Correct the zerovm-devel mailing list address
- Fix a small grammar error
