### PR TITLE
ZeroCloud  tutorial, part 1

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -19,6 +19,17 @@ Getting Started with ZeroVM
    glossary
 
 
+The ZeroCloud Platform
+----------------------
+
+.. toctree::
+   :maxdepth: 2
+
+   zerocloud/overview
+   zerocloud/devenv
+   zerocloud/runningcode
+
+
 The Zebra Playground
 --------------------
 

--- a/zerocloud/devenv.rst
+++ b/zerocloud/devenv.rst
@@ -1,0 +1,114 @@
+.. _devenv:
+
+Setting up a development environment
+==============================================
+
+The easiest way to get up and running is to install and run ZeroCloud on
+DevStack (link) inside VirtualBox. We provide some Vagrant (link) scripts
+to make the setup require little effort.
+
+With this environment, you can not only write and run applications on
+ZeroCloud, but you can also hack on ZeroCloud on itself.
+
+Note to Linux users: There should be packages available (using the favored
+package manager of your distro) for just about everything you need to install.
+
+Install VirtualBox
+------------------
+
+Download and install VirtualBox: https://www.virtualbox.org/wiki/Downloads.
+
+Install Vagrant
+---------------
+
+Download and install Vagrant: https://www.vagrantup.com/downloads.html.
+
+Clone the ZeroCloud source code
+-------------------------------
+
+First, download and install Git: http://git-scm.com/downloads
+
+From a command line, clone the soure code. In this example, we just checkout
+the code into a ``zerocloud`` folder in our home directory.
+
+.. code-block:: bash
+
+    $ git clone https://github.com/zerovm/zerocloud.git $HOME/zerocloud
+
+
+vagrant up
+----------
+
+Now we can actually start OpenStack Swift and ZeroCloud, inside a VM:
+
+.. code-block:: bash
+
+    $ cd $HOME/zerocloud/contrib/vagrant
+    $ vagrant up
+
+``vagrant up`` will download and install DevStack and configure it to run
+Swift with the ZeroCloud middleware. This usually takes about 10-15 minutes.
+
+After the initial installation, you'll need restart DevStack and ZeroCloud.
+To do so, first log in to the the vagrant box:
+
+.. code-block:: bash
+
+    $ vagrant ssh
+
+Next, we need to terminate all of the DevStack processes. The first time you do
+this, you need to use a little brute force. First, run rejoin_stack.sh:
+
+.. code-block:: bash
+
+    $ cd $HOME/devstack
+    $ ./rejoin_stack.sh
+
+This will put you into a screen session. To terminate DevStack, press
+'ctrl+a backslash', then 'y' to confirm. NOTE: The first time you restart
+DevStack after provisioning the machine, not all of the Swift processes will
+be killed. A little brute force is needed:
+
+.. code-block:: bash
+
+    $ ps ax | grep [s]wift | awk '{print $1}' | xargs kill
+
+Now restart DevStack:
+
+.. code-block:: bash
+
+    $ cd $HOME/devstack
+    $ ./rejoin_stack.sh
+
+If you make configuration changes after this first DevStack restart, subsequent
+restarts are easier. Run ``./rejoin_stack.sh`` as above, press
+'ctrl+a backslash', 'y' to confirm, then run ``./rejoin_stack.sh`` again.
+
+To log out of the vagrant box and keep everything running, press 'ctrl+a d' to
+detach from the screen session. You can now log out of the box ('ctrl+d').
+
+Install command line clients
+----------------------------
+
+To interact with and test your ZeroCloud deployment, you'll need to install a
+handful of tools. You can install all of these tools from PyPI using ``pip``.
+
+.. code-block:: bash
+
+    $ pip install python-swiftclient python-keystoneclient zpm
+
+To authenticate with your ZeroCloud installation, you'll need to set up your
+credentials in some environment variables. A configuration file is provided
+for convenience in ``$HOME/zerocloud/contrib/vagrant``.
+
+.. code-block:: bash
+
+    $ source adminrc
+
+You can test your client configuration by running ``zpm auth``:
+
+.. code-block:: bash
+
+    $ zpm auth
+    Auth token: PKIZ_Zrz_Qa5NJm44FWeF7Wp...
+    Storage URL: http://127.0.0.1:8080/v1/AUTH_7fbcd8784f8843a180cf187bbb12e49c

--- a/zerocloud/overview.rst
+++ b/zerocloud/overview.rst
@@ -1,0 +1,9 @@
+.. _zerocloud-overview:
+
+What is ZeroCloud?
+------------------
+
+ZeroCloud is a middleware application for OpenStack Swift. ZeroCloud combines
+the massively scalable object storage capabilities of Swift with the
+application isolation provided by ZeroVM. The result is a platform which can be
+used to create applications which are truly "cloud applications".

--- a/zerocloud/runningcode.rst
+++ b/zerocloud/runningcode.rst
@@ -1,0 +1,83 @@
+.. _running-code:
+
+Running code on ZeroCloud
+=========================
+
+These examples below include executing code using just plain old ``curl``
+commands on the command line, as well as scripting using Python and the
+``requests`` (link?) module.
+
+Getting an auth token
+---------------------
+
+The first thing you need to do is get an auth token and find the storage URL
+for your account in Swift. For convenience, you can get this information simply
+by running ``zpm auth``:
+
+.. code-block:: bash
+
+    $ zpm auth
+    Auth token: PKIZ_Zrz_Qa5NJm44FWeF7Wp...
+    Storage URL: http://127.0.0.1:8080/v1/AUTH_7fbcd8784f8843a180cf187bbb12e49c
+
+Setting a couple of environment variables with these values will make commands
+more concise and convenient to execute:
+
+.. code-block:: bash
+
+    $ export OS_AUTH_TOKEN=PKIZ_Zrz_Qa5NJm44FWeF7Wp...
+    $ export OS_STORAGE_URL=http://127.0.0.1:8080/v1/AUTH_7fbcd8784f8843a180cf187bbb12e49c
+
+POST a Python script
+--------------------
+
+This is the simplest and easiest way to execute code on ZeroCloud.
+
+First, write the following the code into a file called ``pyscript``.
+
+.. code-block:: python
+
+    #!file://python2.7:python
+    import sys
+    print("Hello from ZeroVM!")
+    print("sys.platform is '%s'" % sys.platform)
+
+Execute it using ``curl``:
+
+.. code-block:: bash
+
+    $ curl -i -X POST -H "X-Auth-Token: $OS_AUTH_TOKEN" -H "X-Zerovm-Execute: 1.0" -H "Content-Type: application/python" --data-binary @pyscript $OS_STORAGE_URL
+
+
+Using a Python script:
+
+.. code-block:: python
+
+    import os
+    import requests
+
+    storage_url = os.environ.get('OS_STORAGE_URL')
+    headers = {
+        'X-Zerovm-Execute': 1.0,
+        'X-Auth-Token': os.environ.get('OS_AUTH_TOKEN'),
+        'Content-Type': 'application/python',
+    }
+
+    with open('pyscript') as fp:
+        response = requests.post(storage_url,
+                                 data=fp.read(),
+                                 headers=headers)
+        print(response.content)
+
+You can write and execute any Python code in this way, using any of the modules
+in the standard library.
+
+POST a ZeroVM image
+-------------------
+
+TODO
+
+POST a job description to a ZeroVM application (zapp)
+-----------------------------------------------------
+
+TODO


### PR DESCRIPTION
Partially depends on https://github.com/zerovm/zpm/pull/184. If https://github.com/zerovm/zpm/pull/184 is not accepted, this needs to be revised.

This slightly changes the structure of our docs. Zebra docs are pushed down and more emphasis is put on ZeroCloud. 

Most of this patch includes complete setup instructions for installing and running ZeroCloud on DevStack and setting up command clients. The only "real" tutorial included is based on https://github.com/zerovm/zerocloud/blob/swift-2.0/doc/Requests.md#post-any-other-file. Some other follow on tutorials have been stubbed out with `TODO` to give an idea of what comes next.
