### PR TITLE
snakebin: mv OS_STORAGE_TOKEN OS_STORAGE_ACCOUNT

### DIFF
--- a/zerocloud/snakebin/snakebin.rst
+++ b/zerocloud/snakebin/snakebin.rst
@@ -346,16 +346,16 @@ commands more concise and convenient to execute:
 
 .. code-block:: bash
 
-    $ export OS_STORAGE_TOKEN=AUTH_123def...
+    $ export OS_STORAGE_ACCOUNT=AUTH_123def...
 
 Configure the endpoint handler zapp for ``snakebin-api``, ``snakebin-app``, and
 ``snakebin-store``:
 
 .. code-block:: bash
 
-    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_TOKEN/snakebin-app/snakebin.zapp" snakebin-api
-    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_TOKEN/snakebin-app/snakebin.zapp" snakebin-app
-    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_TOKEN/snakebin-app/snakebin.zapp" snakebin-store
+    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_ACCOUNT/snakebin-app/snakebin.zapp" snakebin-api
+    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_ACCOUNT/snakebin-app/snakebin.zapp" snakebin-app
+    $ swift post --header "X-Container-Meta-Rest-Endpoint: swift://$OS_STORAGE_ACCOUNT/snakebin-app/snakebin.zapp" snakebin-store
 
 We'll also need to set execution permissions for unauthenticated (anonymous)
 users on the same three containers:
@@ -385,13 +385,13 @@ Now upload it:
 .. code-block:: bash
 
     $ curl -X POST -H "X-Zerovm-Execute: api/1.0" $OS_STORAGE_URL/snakebin-api --data-binary @example.py
-    http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/GDHh7vR3Zb
+    http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/GDHh7vR3Zb
 
 The URL returned from the ``POST`` can be used to retrieve the document:
 
 .. code-block:: bash
 
-    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/GDHh7vR3Zb
+    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/GDHh7vR3Zb
     print "hello world!"
 
 .. note:: Note that in the ``POST`` we have to supply the
@@ -402,7 +402,7 @@ The URL returned from the ``POST`` can be used to retrieve the document:
     browser.
 
 We can also try this through the web interface. Open a web browser and go to
-``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api``. You should get a
+``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api``. You should get a
 page that looks something like this:
 
 .. image:: snakebin_part1_ui.png
@@ -410,7 +410,7 @@ page that looks something like this:
 
 Type some text into the box and play around with saving documents. You can also
 try to browse the the document we created above on the command line
-(``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/GDHh7vR3Zb``).
+(``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/GDHh7vR3Zb``).
 
 .. _snakebin_part2:
 
@@ -524,7 +524,7 @@ done simply by ``curl``ing the URL of the script and appending ``/execute``:
 
 .. code-block:: bash
 
-    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/GDHh7vR3Zb/execute
+    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/GDHh7vR3Zb/execute
     hello world!
 
 Next, let's trying posting the ``example.py`` script directly to the
@@ -532,11 +532,11 @@ Next, let's trying posting the ``example.py`` script directly to the
 
 .. code-block:: bash
 
-    $ curl -X POST http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/execute --data-binary @example.py
+    $ curl -X POST http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/execute --data-binary @example.py
     hello world!
 
 Let's also test the functionality in the web browser. If you nagivate to
-``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api``, the new page
+``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api``, the new page
 should look something like this:
 
 .. image:: snakebin_part2_ui.png
@@ -547,7 +547,7 @@ Try writing some code into the text box and click ``Run`` to execute them.
 Try also accessing the ``/snakebin-api/:script/execute`` endpoint directly
 in the browser using the same the URL in the POST example above:
 
-``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/GDHh7vR3Zb/execute``
+``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/GDHh7vR3Zb/execute``
 
 .. _snakebin_part3:
 
@@ -629,14 +629,14 @@ anything, obviously.)
 
 .. code-block:: bash
 
-    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/search?q=foo
-    ["http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/IOFW0Z8UYR", "http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api/e2X0hNA9ld"]
+    $ curl http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/search?q=foo
+    ["http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/IOFW0Z8UYR", "http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api/e2X0hNA9ld"]
 
 Let's also test the functionality in the web browser. If you navigate to
-``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api``, the new page
+``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api``, the new page
 should look something like this:
 
-``http://127.0.0.1:8080/api/$OS_STORAGE_TOKEN/snakebin-api``, the new page
+``http://127.0.0.1:8080/api/$OS_STORAGE_ACCOUNT/snakebin-api``, the new page
 should look something like this:
 
 .. image:: snakebin_part3_ui.png


### PR DESCRIPTION
OS_STORAGE_TOKEN doesn't seem like the right name, and may be confused
with the X-Storage-Token header (similar in use to the X-Auth-Token
header submitted with Swift HTTP requests). (See
http://docs.openstack.org/developer/swift/overview_auth.html for more
information about X-Storage-Token.)

Also, the data this variable represents is not a storage token; it's the
ID of the storage account. Therefore, OS_STORAGE_ACCOUNT is a better
name.
