### PR TITLE
pythonapps: changed `depends` to `dependencies`

### DIFF
--- a/zerocloud/pythonapps.rst
+++ b/zerocloud/pythonapps.rst
@@ -178,7 +178,7 @@ cached Python packages. To do this, you can simply run:
 
     $ zpm bundle --refresh-deps
 
-This will clear the cache, re-fetch all dependencies per the ``depends``
+This will clear the cache, re-fetch all dependencies per the ``dependencies``
 directive in the ``zapp.yaml``, and bundle your zapp as usual.
 
 .. tip::


### PR DESCRIPTION
In the initial draft of this feature, the directive was called `depends`
but was later renamed to `dependencies`. I somehow missed this instance
of it when I wrote the docs.
